### PR TITLE
Try loading NSS by simple name first (fixes issue #4)

### DIFF
--- a/extension/domcrypt/content/DOMCryptMethods.jsm
+++ b/extension/domcrypt/content/DOMCryptMethods.jsm
@@ -278,13 +278,17 @@ var DOMCryptMethods = {
    *
    * @param Object aConfigObject
    * @param String aSharedObjectPath
-   *        The path to the NSS shared object
+   *        The full path to the NSS shared object
+   * @param String aSharedObjectName
+   *        The name of the NSS shared object
    * @returns void
    */
-  init: function DCM_init(aConfigObject, aSharedObjectPath)
+  init: function DCM_init(aConfigObject, aSharedObjectPath, aSharedObjectName)
   {
     this.config = aConfigObject;
-    worker.postMessage({action: INITIALIZE_WORKER, nssPath: aSharedObjectPath});
+    worker.postMessage({ action: INITIALIZE_WORKER,
+                         fullPath: aSharedObjectPath,
+                         libName: aSharedObjectName });
   },
 
   /**
@@ -1337,13 +1341,13 @@ function initializeDOMCrypt()
           throw new Error("Cannot write config object file to disk");
         }
         let configObj = JSON.parse(data);
-        DOMCryptMethods.init(configObj, fullPath);
+        DOMCryptMethods.init(configObj, fullPath, libName);
       });
     }
     else {
       data = NetUtil.readInputStreamToString(inputStream, inputStream.available());
       let configObj = JSON.parse(data);
-      DOMCryptMethods.init(configObj, fullPath);
+      DOMCryptMethods.init(configObj, fullPath, libName);
     }
   });
 }

--- a/extension/domcrypt/content/domcrypt_worker.js
+++ b/extension/domcrypt/content/domcrypt_worker.js
@@ -81,7 +81,14 @@ onmessage = function domcryptWorkerOnMessage(aEvent)
 
   switch(aEvent.data.action) {
   case INITIALIZE:
-    WeaveCrypto.initNSS(aEvent.data.nssPath);
+    // try to open the library through its name only
+    try {
+      WeaveCrypto.initNSS(aEvent.data.libName);
+    }
+    // if this fails we need to provide the full path
+    catch (ex) {
+      WeaveCrypto.initNSS(aEvent.data.fullPath);
+    }
     break;
   case GENERATE_KEYPAIR:
     result = WeaveCryptoWrapper.generateKeypair(aEvent.data.passphrase);


### PR DESCRIPTION
On Fedora 18 (and possibly other GNU/Linux distributions), the NSS library is not located in `/usr/lib/firefox/xulrunner/` which is the path returned by `Services.dirsvc.get("GreD", Ci.nsILocalFile)`. The library can be loaded when only its name is provided.

This commit patches the initialisation code such that the simple name is tried first. If the library cannot be found, the full path is tried instead. 
